### PR TITLE
fix: harden yup client interop with optimizeDeps and runtime template

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -12,12 +12,12 @@ export const VALID_TYPES: YupExtensionType[] = [
 ]
 
 export const TYPE_MAP: Record<YupExtensionType, string> = {
-  string: 'Yup.StringSchema',
-  number: 'Yup.NumberSchema',
-  boolean: 'Yup.BooleanSchema',
-  object: 'Yup.ObjectSchema',
-  array: 'Yup.ArraySchema',
-  date: 'Yup.DateSchema',
-  mixed: 'Yup.Schema',
-  schema: 'Yup.Schema',
+  string: 'yup.StringSchema',
+  number: 'yup.NumberSchema',
+  boolean: 'yup.BooleanSchema',
+  object: 'yup.ObjectSchema',
+  array: 'yup.ArraySchema',
+  date: 'yup.DateSchema',
+  mixed: 'yup.Schema',
+  schema: 'yup.Schema',
 }

--- a/src/generators/runtimeTemplate.ts
+++ b/src/generators/runtimeTemplate.ts
@@ -22,7 +22,7 @@ export function generateMode1Template(descriptors: YupExtensionDescriptor[]): st
     validators.push(`const ${validatorVar} = ${validateSource};`)
 
     methods.push(`
-  Yup.addMethod(${typeName}, '${descriptor.name}', function (message) {
+  yup.addMethod(${typeName}, '${descriptor.name}', function (message) {
     return this.test(
       'custom-${descriptor.name}',
       message || '${escapedMessage}',
@@ -35,8 +35,7 @@ export function generateMode1Template(descriptors: YupExtensionDescriptor[]): st
   });`)
   }
 
-  return `import * as Yup from 'yup';
-
+  return `
 ${validators.join('\n')}
 
 export async function applyExtensions(yup) {

--- a/src/module.ts
+++ b/src/module.ts
@@ -19,6 +19,18 @@ export default defineNuxtModule<ModuleOptions>({
   async setup(options, nuxt) {
     const { resolve } = createResolver(import.meta.url)
 
+    // Fix ESM/CJS interop: yup's transitive dep tiny-case is CJS-only and fails
+    // named-export resolution in the browser when loaded as raw ESM. Adding
+    // yup and tiny-case to Vite's optimizeDeps forces pre-bundling on the client
+    // dev server, which properly converts CJS→ESM without touching the SSR path.
+    nuxt.options.vite.optimizeDeps ??= {}
+    nuxt.options.vite.optimizeDeps.include ??= []
+    for (const pkg of ['yup', 'tiny-case']) {
+      if (!nuxt.options.vite.optimizeDeps.include.includes(pkg)) {
+        nuxt.options.vite.optimizeDeps.include.push(pkg)
+      }
+    }
+
     // Add base plugin
     addPlugin(resolve('./runtime/plugins/yup'))
     addImportsDir(resolve('./runtime/composables'))


### PR DESCRIPTION
This pull request addresses compatibility and integration issues with the `yup` validation library, focusing on improving ESM/CJS interop and ensuring consistent usage throughout the codebase. The main changes include updating type references, fixing method calls, and configuring the development server for better module resolution.

**ESM/CJS Interop Improvements**
* [`src/module.ts`](diffhunk://#diff-030fc083b2cbf5cf008cfc0c49bb4f1b8d97ac07f93a291d068d81b4d1416f70R22-R33): Adds both `yup` and its transitive dependency `tiny-case` to Vite's `optimizeDeps.include` array. This forces pre-bundling on the client dev server, resolving issues with CJS-only dependencies when used as ESM in the browser.

**Consistency in `yup` Usage**
* [`src/constants.ts`](diffhunk://#diff-8fa4b52909f895e8cda060d2035234e0a42ca2c7d3f8f8de1b35a056537bf199L15-R22): Changes all references in `TYPE_MAP` from `Yup.*` to `yup.*` to ensure consistent naming and avoid confusion.
* [`src/generators/runtimeTemplate.ts`](diffhunk://#diff-465bbcf6abf50159fb85b2d8158d395ca027495ff1bd7bd994cc2dbc2f89f730L25-R25): Updates the `addMethod` call from `Yup.addMethod` to `yup.addMethod` for consistency with the rest of the codebase.
* [`src/generators/runtimeTemplate.ts`](diffhunk://#diff-465bbcf6abf50159fb85b2d8158d395ca027495ff1bd7bd994cc2dbc2f89f730L38-R38): Removes the explicit `import * as Yup from 'yup';` statement, reflecting the shift to using the lowercase `yup` identifier, which is now expected to be passed in as a parameter.